### PR TITLE
Proposal: easy importing

### DIFF
--- a/myeia/api.py
+++ b/myeia/api.py
@@ -65,8 +65,11 @@ class API:
     Documentation:
         https://www.eia.gov/opendata/documentation.php
     """
+    def __init__(self, token):
+        self.token: Optional[str] = token
 
-    token: Optional[str] = os.getenv("EIA_TOKEN")  # Get API token from .env file
+        #token: Optional[str] = os.getenv("EIA_TOKEN") 
+    
     base_url: str = "https://api.eia.gov/v2/"
     header: dict = field(default_factory=lambda: {"Accept": "*/*"})
 


### PR DESCRIPTION
I think this method would be much easier to use. 

You can directly import the key while declaring API() as API(EIA_Token).
Users can import from .env in the script, I think it makes more sense to do this than to import a .env variable inside a class. 